### PR TITLE
Use stage space origin when getting tracking data from Oculus SDK

### DIFF
--- a/app/src/main/cpp/ovr_context.cpp
+++ b/app/src/main/cpp/ovr_context.cpp
@@ -443,6 +443,8 @@ void OvrContext::fetchTrackingInfo(JNIEnv *env_, jobject udpReceiverThread, ovrV
     frame->frameIndex = FrameIndex;
     frame->fetchTime = getTimestampUs();
 
+    //If VRAPI_TRACKING_SPACE_STAGE is not set, the coordinate origin OpenVR receives will not be consistent when the headset state changes or user recenters
+    vrapi_SetTrackingSpace(Ovr, VRAPI_TRACKING_SPACE_STAGE);
     frame->displayTime = vrapi_GetPredictedDisplayTime(Ovr, FrameIndex);
     frame->tracking = vrapi_GetPredictedTracking2(Ovr, frame->displayTime);
 


### PR DESCRIPTION
Right now the coordinates SteamVR receives are not necessarily consistent. If the headset loses tracking, the client gets restarted, or interrupted some other way, there's no guarantee that origin will stay in the same place.

This is critical if using tools where the Quest's coordinate system is aligned with something else, like a real world camera with [LIV](https://liv.tv/) or an external Lighthouse tracking system for Vive/Knuckles controllers/trackers using [OpenVR Space Calibrator](https://github.com/pushrax/OpenVR-SpaceCalibrator). Having this enabled is a massive help when we're creating mixed reality content with the Quest.

While this does disable the Quest's built in recentering feature, SteamVR's will still work. This is how the Rift behaves when used with SteamVR.

Edit: OvrTrackingSpace info: https://developer.oculus.com/documentation/mobilesdk/latest/concepts/mobile-native-migration/