### PR TITLE
Prevent the compatibility mode in Oculus Quest

### DIFF
--- a/app/src/Ovr/AndroidManifest.xml
+++ b/app/src/Ovr/AndroidManifest.xml
@@ -3,9 +3,18 @@
     package="com.polygraphene.alvr"
     android:installLocation="auto">
 
+    <!--
+        Request the system to provide us the 6DoF tracking headset features
+        Latest versions of Oculus Quest firmware run in Oculus Go compatibility mode without this,
+        which makes only one of the controllers available at a time
+    -->
+    <uses-feature android:name="android.hardware.vr.headtracking"
+        android:version="1" android:required="false" />
+
     <uses-feature
         android:glEsVersion="0x00030001"
         android:required="true" />
+
     <application>
 
         <meta-data


### PR DESCRIPTION
The latest firmware update introduced some kind of compatibility mode
for (probably?) Oculus Go which activates if you don't specify the
android.hardware.vr.headtracking feature. This broke most of sideloaded
apps as this was usually only truly required when submitting the app to
Oculus Store.

Note that I specified required="false" to make sure we still can run on
3DoF headsets. Most people are talking about using the line with
required="true", but this is the correct way for hybrid apps according
to Oculus docs (and it works)

Credits to everybody who figured out this issue before me. See https://www.reddit.com/r/OculusQuest/comments/chjpu5/fix_for_sideloadedhomebrew_apps_and_games_with/

Closes polygraphene/ALVR#479, polygraphene/ALVR#477, polygraphene/ALVR#476