### PR TITLE
Configuration setting for explicit server IP

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,10 @@
         android:theme="@style/AppTheme">
         <activity android:name=".test.DecoderTestActivity"><intent-filter>
             <action android:name="android.intent.action.MAIN" /></intent-filter></activity>
+        <service
+            android:name="ChangeSettings"
+            android:exported="true"
+            android:permission="android.permission.WRITE_SETTINGS" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/polygraphene/alvr/BaseActivity.java
+++ b/app/src/main/java/com/polygraphene/alvr/BaseActivity.java
@@ -11,7 +11,7 @@ abstract class BaseActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        PersistentConfig.loadCurrentConfig(this);
+        PersistentConfig.loadCurrentConfig(this, true);
         super.onCreate(savedInstanceState);
         ArThread.requestPermissions(this);
     }

--- a/app/src/main/java/com/polygraphene/alvr/ChangeSettings.java
+++ b/app/src/main/java/com/polygraphene/alvr/ChangeSettings.java
@@ -1,0 +1,32 @@
+package com.polygraphene.alvr;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+public class ChangeSettings extends Service {
+    private static final String TAG = "ChangeSettings";
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        PersistentConfig.loadCurrentConfig(this);
+
+        Utils.logi(TAG, () -> "Config setting " + PersistentConfig.KEY_TARGET_SERVERS + " has value: " + PersistentConfig.sTargetServers);
+
+        String targetServers = intent.getStringExtra(PersistentConfig.KEY_TARGET_SERVERS);
+
+        if (targetServers != null) {
+            Utils.logi(TAG, () -> "Setting config setting " + PersistentConfig.KEY_TARGET_SERVERS + " to: " + targetServers);
+            PersistentConfig.sTargetServers = targetServers;
+        }
+
+        PersistentConfig.saveCurrentConfig();
+        stopSelf(startId);
+        return Service.START_NOT_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+}

--- a/app/src/main/java/com/polygraphene/alvr/ChangeSettings.java
+++ b/app/src/main/java/com/polygraphene/alvr/ChangeSettings.java
@@ -9,7 +9,7 @@ public class ChangeSettings extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        PersistentConfig.loadCurrentConfig(this);
+        PersistentConfig.loadCurrentConfig(this, false);
 
         Utils.logi(TAG, () -> "Config setting " + PersistentConfig.KEY_TARGET_SERVERS + " has value: " + PersistentConfig.sTargetServers);
 
@@ -20,7 +20,7 @@ public class ChangeSettings extends Service {
             PersistentConfig.sTargetServers = targetServers;
         }
 
-        PersistentConfig.saveCurrentConfig();
+        PersistentConfig.saveCurrentConfig(false);
         stopSelf(startId);
         return Service.START_NOT_STICKY;
     }

--- a/app/src/main/java/com/polygraphene/alvr/PersistentConfig.java
+++ b/app/src/main/java/com/polygraphene/alvr/PersistentConfig.java
@@ -10,6 +10,7 @@ public class PersistentConfig {
     private static final String KEY_SERVER_ADDRESS = "serverAddress";
     private static final String KEY_SERVER_PORT = "serverPort";
     private static final String KEY_DEBUG_FLAGS = "debugFlags";
+    public static final String KEY_TARGET_SERVERS = "targetServers";
 
     public static class ConnectionState {
         public String serverAddr;
@@ -18,12 +19,14 @@ public class PersistentConfig {
 
     private static Context sAppContext = null;
     public static long sDebugFlags = 0;
+    public static String sTargetServers = null;
 
     // Save current configs for next startup.
     public static void saveCurrentConfig() {
         SharedPreferences pref = sAppContext.getSharedPreferences("pref", Context.MODE_PRIVATE);
         SharedPreferences.Editor edit = pref.edit();
         edit.putLong(KEY_DEBUG_FLAGS, sDebugFlags);
+        edit.putString(KEY_TARGET_SERVERS, sTargetServers);
         edit.apply();
         Utils.setDebugFlags(sDebugFlags);
     }
@@ -34,6 +37,7 @@ public class PersistentConfig {
 
         SharedPreferences pref = sAppContext.getSharedPreferences("pref", Context.MODE_PRIVATE);
         sDebugFlags = pref.getLong(KEY_DEBUG_FLAGS, 0);
+        sTargetServers = pref.getString(KEY_TARGET_SERVERS, null);
         Utils.setDebugFlags(sDebugFlags);
     }
 

--- a/app/src/main/java/com/polygraphene/alvr/PersistentConfig.java
+++ b/app/src/main/java/com/polygraphene/alvr/PersistentConfig.java
@@ -22,23 +22,27 @@ public class PersistentConfig {
     public static String sTargetServers = null;
 
     // Save current configs for next startup.
-    public static void saveCurrentConfig() {
+    public static void saveCurrentConfig(boolean reloadDebugFlags) {
         SharedPreferences pref = sAppContext.getSharedPreferences("pref", Context.MODE_PRIVATE);
         SharedPreferences.Editor edit = pref.edit();
         edit.putLong(KEY_DEBUG_FLAGS, sDebugFlags);
         edit.putString(KEY_TARGET_SERVERS, sTargetServers);
         edit.apply();
-        Utils.setDebugFlags(sDebugFlags);
+        if (reloadDebugFlags) {
+            Utils.setDebugFlags(sDebugFlags);
+        }
     }
 
     // Load previous saved config when startup app.
-    public static void loadCurrentConfig(Context context) {
+    public static void loadCurrentConfig(Context context, boolean reloadDebugFlags) {
         sAppContext = context.getApplicationContext();
 
         SharedPreferences pref = sAppContext.getSharedPreferences("pref", Context.MODE_PRIVATE);
         sDebugFlags = pref.getLong(KEY_DEBUG_FLAGS, 0);
         sTargetServers = pref.getString(KEY_TARGET_SERVERS, null);
-        Utils.setDebugFlags(sDebugFlags);
+        if (reloadDebugFlags) {
+            Utils.setDebugFlags(sDebugFlags);
+        }
     }
 
     public static void saveConnectionState(Context context, String serverAddr, int serverPort) {

--- a/app/src/main/java/com/polygraphene/alvr/UdpReceiverThread.java
+++ b/app/src/main/java/com/polygraphene/alvr/UdpReceiverThread.java
@@ -126,6 +126,10 @@ class UdpReceiverThread extends ThreadBase implements TrackingThread.TrackingCal
         try {
             String[] targetList = getTargetAddressList();
 
+            for (String target: targetList) {
+                Utils.logi(TAG, () -> "Target IP address for hello datagrams: " + target);
+            }
+
             mNativeHandle = initializeSocket(HELLO_PORT, PORT, getDeviceName(), targetList,
                     mDeviceDescriptor.mRefreshRates, mDeviceDescriptor.mRenderWidth, mDeviceDescriptor.mRenderHeight, mDeviceDescriptor.mFov,
                     mDeviceDescriptor.mDeviceType, mDeviceDescriptor.mDeviceSubType, mDeviceDescriptor.mDeviceCapabilityFlags,
@@ -239,7 +243,7 @@ class UdpReceiverThread extends ThreadBase implements TrackingThread.TrackingCal
     @SuppressWarnings("unused")
     public void onChangeSettings(long debugFlags, int suspend, int frameQueueSize) {
         PersistentConfig.sDebugFlags = debugFlags;
-        PersistentConfig.saveCurrentConfig();
+        PersistentConfig.saveCurrentConfig(true);
         mCallback.onChangeSettings(suspend, frameQueueSize);
     }
 


### PR DESCRIPTION
Server IP can be set by:
`adb shell am startservice -n "com.polygraphene.alvr/.ChangeSettings" --es "targetServers" "10.10.10.10"`
Multiple IP addresses can be separated by comma.

Setting can be effectively removed by:
`adb shell am startservice -n "com.polygraphene.alvr/.ChangeSettings" --es "targetServers" "none"`

DNS names are currently not supported. 

This should provide native support for ALVR server and VR headset on different subnets/networks (e.g. ALVR over VPN and cloud gaming). 

This closes (however - without the new GUI element): https://github.com/polygraphene/ALVRClient/issues/25